### PR TITLE
Added FOSSASIA Google Plus link in the navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,11 @@
                             <i class="icon social_facebook"></i>
                         </a>
                     </li>
+                     <li class="social-link hidden-md hidden-sm hidden-xs">
+                        <a target="_self" href="https://plus.google.com/108920596016838318216" target="_blank">
+                            <i class="icon social_googleplus"></i>
+                        </a>
+                    </li>
                     <li class="social-link hidden-md hidden-sm hidden-xs">
                         <a target="_self" href="https://github.com/fossasia">
                             <i class="fa fa-github fa-lg"></i>


### PR DESCRIPTION
The Google Plus link was absent from the nav bar section.
 - Preview link : https://sahilsaha7773.github.io/2019-fossasia/
 - Fixes #43 

**Screenshots**
**Before :**

![b](https://user-images.githubusercontent.com/35343652/48826085-6c6d2a80-ed8f-11e8-9e43-3567a5f3448f.PNG)

**After :**

![a](https://user-images.githubusercontent.com/35343652/48826129-873f9f00-ed8f-11e8-8ee4-d866ce585af3.PNG)
