### PR TITLE
fixes #56 (Made the Navbar responsive)

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,14 +62,14 @@
         <nav class="overlay-nav">
             <div class="container">
                 <div class="row">
-                    <div class="col-md-2">
+                    <div class="col-sm-2">
                         <a target="_self" href="https://fossasia.org">
                             <img alt="FOSSASIA Summit" class="logo logo-light" src="img/fossasia-long.png">
                             <img alt="FOSSASIA" class="logo logo-dark" src="img/fossasia-dark.png">
                         </a>
                     </div>
     
-                    <div class="col-md-10 text-right">
+                    <div class="col-sm-10 text-right">
                         <ul class="menu">
                             <li>
                                 <a target="default" class="inner-link" href="#top">Home</a>


### PR DESCRIPTION
fixes #56 
Preview Link : https://tantrojan.github.io/2019.fossasia.org/
**BEFORE:**
The Fossasia logo was overlaping with the menu options for range 768px to 992px.
![f1](https://user-images.githubusercontent.com/29725484/49657514-df4ff400-fa65-11e8-9d04-cafe9c77ac5f.png)

**AFTER**
Issue Solved
![f2](https://user-images.githubusercontent.com/29725484/49657562-f858a500-fa65-11e8-9996-66a2d12e5922.png)
