### PR TITLE
fix header text color on exhibitions page

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -101,6 +101,13 @@
 .item .wp-post-image{
   height: auto;
 }
+.header-text:hover {
+  color: #C3BFBF !important;
+}
+.header-text:focus {
+  color: #fff;
+  text-decoration: none;
+}
 @media screen and (min-width: 350px) and (max-width: 440px)
 {
   #DevPrograms{

--- a/exhibition/index.html
+++ b/exhibition/index.html
@@ -280,8 +280,8 @@
                         <i class="icon pe-7s-glasses"></i>
                         <i class="icon pe-7s-sun icon-large"></i>
                         <h1 class="text-white">FOSSASIA Summit Exhibition<br>
-                            <a class="inner-link" target="_self" href="#exhibitors">Tech Companies</a> and Open Source Projects<br>
-                            Opening with Lunch Snacks on <a class="inner-link" target="_self" href="#exhibitionschedule">Thu, March 14 at 12.00pm, opens till 6pm.<br>
+                            <a class="inner-link header-text" target="_self" href="#exhibitors">Tech Companies</a> and Open Source Projects<br>
+                            Opening with Lunch Snacks on <a class="inner-link header-text" target="_self" href="#exhibitionschedule">Thu, March 14 at 12.00pm, opens till 6pm.<br>
                             Runs From 10am - 6pm on Fri/Sat and until 4pm on Sun, March 17</a></h1>
                     </div>
                 </div>


### PR DESCRIPTION
**Current behaviour:** Currently header text on exhibitions page is blue on activation.
**Expected:** it should be white.
Fixes: #50 

Deployment Link: https://adityasrivast.github.io/2019.fossasia.org/