### PR TITLE
signup up button responsive which is ovarlapping to workshop button  (Bug SOLVED)

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -144,6 +144,35 @@
     padding: 15px 0px 15px 0px;
   }
 }
+/* added media query for the signuphere button overlapping to worshop schedule  */
+@media screen and (min-width: 375px) and (max-width: 812px)
+{
+.btn{
+  margin-bottom: 15px;
+
+}
+
+}
+@media screen and (min-width: 360px) and (max-width: 640px)
+{
+.btn{
+  margin-bottom: 15px;
+
+}
+
+}
+@media screen and (min-width: 320px) and (max-width: 568px)
+{
+.btn{
+  margin-bottom: 15px;
+
+}
+
+}
+
+
+
+
 /*css classes for hiding and showing Donation and regular supporter parts in donate.html*/
 .appear{
   display: block;


### PR DESCRIPTION

![signup and workshop overlapping 2019(foss)](https://user-images.githubusercontent.com/65535360/86531998-f37b0200-bee3-11ea-9371-ae0c3c2ccbef.PNG)
![sign up solved issue 2019 foss 2019](https://user-images.githubusercontent.com/65535360/86531999-f970e300-bee3-11ea-86ff-a5f26959340d.PNG)

#176 issue fixed 
@chaitanya @mariobehling 
SIGNUPFREE button OVERLAPING with WORSHOP SCEHULDE BUTTON **this issue only need margin-bottom to give the distance **
and i also find that this bug is found in the different different screen width so i added a little bit more Media Queeery
so that the users cannot faced this problem .........

<!-- Please read and understand everything below
**Do not delete any text other than where you are instructed to.** -->

<!-- **Students: If one of them is applicable to you. Please check it.** -->

<!-- Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.-->

- [ ] Included a Preview link and screenshot showing after and before the changes.
- [ ] Included a description of the change below.
- [ ] Squashed the commits.

# Changes done in this Pull Request

<!-- If your change will be reflected on the website, please provide a Test Link-->
- [Preview Link](url)
<!-- If you fully fixed some issue, please insert the issue number after the #.
If you have not completely fixed an issue but only some part of it, then remove “Fixes #” and simply link the PR to the issue by writing '#<Issue Number>' -->
- Fixes #<Issue Number>


## Description / Changes



## Screenshots if any:
### Before:

### After:



- - - - - - - - - - - -
<!-- [preview link url]: https://<github_username>.github.io/<name_of_repository> -->
<!-- [squash]:https://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git-->
<!--[squash2]https://davidwalsh.name/squash-commits-git-->
