### PR TITLE
social icon overlapping issue is fixed

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-2019.fossasia.org
+www.svk1.wordpress.com

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-cayman
+theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-slate
+theme: jekyll-theme-minimal

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -1168,6 +1168,7 @@ nav .container {
   border-radius: 50%;
   color: #fff;
   margin-right: 12px;
+  margin-bottom: 24px;
   font-size: 24px;
   line-height: 60px;
 }


### PR DESCRIPTION
to avoid over lapping those social icons in the bottom of the page I applied margin for the bottom of the icons.

<!-- Please read and understand everything below
**Do not delete any text other than where you are instructed to.** -->

<!-- **Students: If one of them is applicable to you. Please check it.** -->

<!-- Check by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.-->

- [x] Included a Preview link and screenshot showing after and before the changes.
- [x] Included a description of the change below.
- [x] Squashed the commits.

# Changes done in this Pull Request

<!-- If your change will be reflected on the website, please provide a Test Link-->
- [Preview Link](url)
<!-- If you fully fixed some issue, please insert the issue number after the #.
If you have not completely fixed an issue but only some part of it, then remove “Fixes #” and simply link the PR to the issue by writing '#<Issue Number>' -->
- Fixes #<Issue Number>


## Description / Changes

social icon overlapping bug fixed

## Screenshots if any:
### Before:

![before(bug)](https://user-images.githubusercontent.com/72222987/101716137-b9c9ab00-3ac2-11eb-926b-b20a09da2a36.jpg)

###After:

![after (bug fixed)](https://user-images.githubusercontent.com/72222987/101716156-c3531300-3ac2-11eb-9002-3c9c2dc94240.jpg)

- - - - - - - - - - - -
<!-- [preview link url]: https://<github_username>.github.io/<name_of_repository> -->
<!-- [squash]:https://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git-->
<!--[squash2]https://davidwalsh.name/squash-commits-git-->
